### PR TITLE
 general: use open(obj) instead of obj.open()

### DIFF
--- a/sclack/app.py
+++ b/sclack/app.py
@@ -1051,14 +1051,19 @@ class App:
 
 def load_configuration():
     filepath = Path(__file__).parent / 'resources' / 'config.yaml'
-    with filepath.open() as config_file:
+
+    with open(filepath) as config_file:
         json_config = yaml.load(config_file, Loader=yaml.FullLoader)
+
     filepath = Path('~/.sclack').expanduser()
     config_dir = Path(os.environ.get('XDG_CONFIG_HOME') or '~/.config').expanduser() / 'sclack'
+
     if not filepath.exists():
         filepath = config_dir / 'config.json'
+
     if not filepath.exists():
         filepath = config_dir / 'config.yaml'
+
     if not filepath.exists():
         ask_for_token(json_config)
         if not config_dir.exists():
@@ -1069,11 +1074,12 @@ def load_configuration():
             elif filepath.suffix == '.yaml':
                 yaml.dump(json_config, config_file)
     else:
-        with filepath.open() as config_file:
+        with open(filepath) as config_file:
             if filepath.suffix == '.json':
                 json_config.update(json.load(config_file))
             elif filepath.suffix == '.yaml':
                 json_config.update(yaml.load(config_file, Loader=yaml.FullLoader))
+
     return json_config
 
 


### PR DESCRIPTION
Sending PRs to this one since it seems to be the more up-to-date one.

This PR makes just a small enhancement to fit general python code. More incoming.