### PR TITLE
image: do not throw image loading errors on screen

### DIFF
--- a/sclack/image.py
+++ b/sclack/image.py
@@ -1,4 +1,5 @@
 import subprocess
+import os
 
 import urwid
 
@@ -60,7 +61,8 @@ def img_to_ansi(path, width, height):
     if height:
         command.extend(['-H', str(height)])
     try:
-        ansi_text = subprocess.check_output(command)
+        with open(os.devnull, 'w') as devnull:
+            ansi_text = subprocess.run(command, check=True, stdout=None, stderr=devnull).stdout
     except (FileNotFoundError, subprocess.CalledProcessError):
         ansi_text = None
     return ansi_text


### PR DESCRIPTION
When using slack, random image error logs would spam through the screen. This PR throws errorlogs out (ideally, they should output to some logfile, but that'll be left for later).